### PR TITLE
Retrieve unavailability information for generation units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ gurobi.log
 *.orig
 .idea
 
+# Environment variables
+.env
+
 /bak
 /resources
 /resources*

--- a/config/gb-model/config.common.yaml
+++ b/config/gb-model/config.common.yaml
@@ -5,6 +5,18 @@
 
 urls:
   gb-etys-boundaries: https://api.neso.energy/dataset/997f4820-1ad4-499b-b1fe-4b8d3d7fbc72/resource/e914fcec-1dc9-4f1f-97e7-59c0d9521bea/download/etys-boundary-gis-data-mar25.zip
+
+# ENTSO-E API configuration
+# Note: Set ENTSO_E_API_KEY in your .env file or environment variables
+unavailability_start_date: "2023-01-01"
+unavailability_end_date: "2024-01-01"
+unavailability_bidding_zones: ["GB"]  # Great Britain only
+unavailability_business_types: ["planned", "forced"]  # planned maintenance and forced outages
+max_request_days: 7  # Maximum days per API request to avoid timeouts
+
+# XML storage configuration
+xml_cleanup_days: 30  # Delete XML files older than 30 days (set to 0 to disable cleanup)
+
 target_crs: "EPSG:27700"
 area_loss_tolerance_percent: 0.01 # percentage of area loss tolerated when splitting regions
 min_region_area: 1000000 # minimum area of a region in square meters (1 km²) for keeping it after splitting

--- a/config/gb-model/config.common.yaml
+++ b/config/gb-model/config.common.yaml
@@ -2,32 +2,30 @@
 #
 # SPDX-License-Identifier: MIT
 
-
 urls:
   gb-etys-boundaries: https://api.neso.energy/dataset/997f4820-1ad4-499b-b1fe-4b8d3d7fbc72/resource/e914fcec-1dc9-4f1f-97e7-59c0d9521bea/download/etys-boundary-gis-data-mar25.zip
 
-# ENTSO-E API configuration
 # Note: Set ENTSO_E_API_KEY in your .env file or environment variables
-unavailability_start_date: "2023-01-01"
-unavailability_end_date: "2024-01-01"
-unavailability_bidding_zones: ["GB"]  # Great Britain only
-unavailability_business_types: ["planned", "forced"]  # planned maintenance and forced outages
-max_request_days: 7  # Maximum days per API request to avoid timeouts
-
-# UK bidding zone codes for ENTSO-E API
-uk_bidding_zones:
-  GB: "10YGB----------A"  # Great Britain
-
-# Business types for outage classification
-business_types:
-  planned: "A53"  # Planned maintenance
-  forced: "A54"   # Forced unavailability (unplanned outage)
-
-# Document status codes
-doc_status:
-  active: "A05"     # Active
-  cancelled: "A09"  # Cancelled
-  withdrawn: "A13"  # Withdrawn
+# Register at https://transparency.entsoe.eu/ to get API key
+unavailability:
+  start_date: "2023-01-01"
+  end_date: "2024-01-01"
+  bidding_zones: ["GB"]  # Great Britain only
+  business_types: ["planned", "forced"]  # planned maintenance and forced outages
+  max_request_days: 7  # Maximum days per API request to avoid timeouts
+  entso_e:
+    # UK bidding zone codes
+    bidding_zones:
+      GB: "10YGB----------A"  # Great Britain
+    # Business types for outage classification
+    business_types:
+      planned: "A53"  # Planned maintenance
+      forced: "A54"   # Forced unavailability (unplanned outage)
+    # Document status codes
+    doc_status:
+      active: "A05"     # Active
+      cancelled: "A09"  # Cancelled
+      withdrawn: "A13"  # Withdrawn
 
 target_crs: "EPSG:27700"
 area_loss_tolerance_percent: 0.01 # percentage of area loss tolerated when splitting regions

--- a/config/gb-model/config.common.yaml
+++ b/config/gb-model/config.common.yaml
@@ -14,6 +14,21 @@ unavailability_bidding_zones: ["GB"]  # Great Britain only
 unavailability_business_types: ["planned", "forced"]  # planned maintenance and forced outages
 max_request_days: 7  # Maximum days per API request to avoid timeouts
 
+# UK bidding zone codes for ENTSO-E API
+uk_bidding_zones:
+  GB: "10YGB----------A"  # Great Britain
+
+# Business types for outage classification
+business_types:
+  planned: "A53"  # Planned maintenance
+  forced: "A54"   # Forced unavailability (unplanned outage)
+
+# Document status codes
+doc_status:
+  active: "A05"     # Active
+  cancelled: "A09"  # Cancelled
+  withdrawn: "A13"  # Withdrawn
+
 target_crs: "EPSG:27700"
 area_loss_tolerance_percent: 0.01 # percentage of area loss tolerated when splitting regions
 min_region_area: 1000000 # minimum area of a region in square meters (1 km²) for keeping it after splitting

--- a/config/gb-model/config.common.yaml
+++ b/config/gb-model/config.common.yaml
@@ -14,9 +14,6 @@ unavailability_bidding_zones: ["GB"]  # Great Britain only
 unavailability_business_types: ["planned", "forced"]  # planned maintenance and forced outages
 max_request_days: 7  # Maximum days per API request to avoid timeouts
 
-# XML storage configuration
-xml_cleanup_days: 30  # Delete XML files older than 30 days (set to 0 to disable cleanup)
-
 target_crs: "EPSG:27700"
 area_loss_tolerance_percent: 0.01 # percentage of area loss tolerated when splitting regions
 min_region_area: 1000000 # minimum area of a region in square meters (1 km²) for keeping it after splitting
@@ -25,37 +22,37 @@ min_region_area: 1000000 # minimum area of a region in square meters (1 km²) fo
 region_operations:
   # Regions to split before merging
   splits:
-    - region: 6
-      type: "vertical"
-      coordinate: -2.48
-    - region: 5
-      type: "vertical" 
-      coordinate: -1.93
-    - region: 8
-      type: "vertical"
-      coordinate: -2.48
-    - region: 46
-      type: "horizontal"
-      coordinate: 53.1
-  
+  - region: 6
+    type: "vertical"
+    coordinate: -2.48
+  - region: 5
+    type: "vertical"
+    coordinate: -1.93
+  - region: 8
+    type: "vertical"
+    coordinate: -2.48
+  - region: 46
+    type: "horizontal"
+    coordinate: 53.1
+
   # Groups of regions to merge together
   merge_groups:
-    - [61, 64]
-    - [47, 48, 49]
-    - [54, 55, 56]
-    - [52, 53]
-    - [41, 43, "46s"]
-    - [77, 78, 79]
-    - [40, 44, 45]
-    - [13, 16, 17]
-    - [80, 81, 82, 83]
-    - [18, 19, 20, 21, 22, 23, 24, 31, 32, 33, 34, 94, 95, 96, 97, 98]
-    - [2, 3, 91, 92]
-    - [14, 15, 25, 26, 27, 28, 29, 30, 35, 36, 37, 38]
-    - [62, 63, 86, 87, 88]
-    - [65, 66, 67, 68, 69, 70, 71, 72, 73, 84, 85]
-    - [10, "6wn", 11, 12, "8w"]
-    - ["6e", "6ws", 7, 9]
-    - [39, 99]
-    - [74, 75, 76]
-    - [4, "5w"]
+  - [61, 64]
+  - [47, 48, 49]
+  - [54, 55, 56]
+  - [52, 53]
+  - [41, 43, "46s"]
+  - [77, 78, 79]
+  - [40, 44, 45]
+  - [13, 16, 17]
+  - [80, 81, 82, 83]
+  - [18, 19, 20, 21, 22, 23, 24, 31, 32, 33, 34, 94, 95, 96, 97, 98]
+  - [2, 3, 91, 92]
+  - [14, 15, 25, 26, 27, 28, 29, 30, 35, 36, 37, 38]
+  - [62, 63, 86, 87, 88]
+  - [65, 66, 67, 68, 69, 70, 71, 72, 73, 84, 85]
+  - [10, "6wn", 11, 12, "8w"]
+  - ["6e", "6ws", 7, 9]
+  - [39, 99]
+  - [74, 75, 76]
+  - [4, "5w"]

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -48,6 +48,7 @@ dependencies:
 - tqdm
 - pytz
 - jpype1
+- python-dotenv
 - pyxlsb
 - graphviz
 - geojson

--- a/rules/gb-model.smk
+++ b/rules/gb-model.smk
@@ -56,3 +56,18 @@ rule manual_region_merger:
         "../envs/environment.yaml"
     script:
         "../scripts/gb-model/manual_region_merger.py"
+
+
+# Rule to retrieve generation unit unavailability data from ENTSO-E
+rule retrieve_unavailability_data:
+    output:
+        gb_planned_unavailability=resources("gb_planned_unavailability.csv"),
+        gb_forced_unavailability=resources("gb_forced_unavailability.csv"),
+    log:
+        logs("retrieve_unavailability_data.log")
+    resources:
+        mem_mb=2000,
+    conda:
+        "../envs/environment.yaml"
+    script:
+        "../scripts/gb-model/retrieve_unavailability_data.py"

--- a/rules/gb-model.smk
+++ b/rules/gb-model.smk
@@ -8,6 +8,7 @@ import subprocess
 from zipfile import ZipFile
 from pathlib import Path
 
+
 configfile: "config/gb-model/config.common.yaml"
 
 
@@ -16,13 +17,15 @@ rule retrieve_etys_boundary_data:
     output:
         boundary_shp="data/gb-model/etys-boundary-gis-data.zip",
     params:
-        url=config["urls"]["gb-etys-boundaries"]
+        url=config["urls"]["gb-etys-boundaries"],
     log:
-        logs("retrieve_etys_boundary_data.log")
+        logs("retrieve_etys_boundary_data.log"),
     resources:
         mem_mb=1000,
-    conda: "../envs/shell.yaml"  # This is required to install `curl` into a conda env on Windows 
-    shell: "curl -sSLvo {output} {params.url}"
+    conda:
+        "../envs/shell.yaml"  # This is required to install `curl` into a conda env on Windows 
+    shell:
+        "curl -sSLvo {output} {params.url}"
 
 
 # Rule to create region shapes using create_region_shapes.py
@@ -31,9 +34,9 @@ rule create_region_shapes:
         country_shapes=resources("country_shapes.geojson"),
         etys_boundary_lines="data/gb-model/etys-boundary-gis-data.zip",
     output:
-        raw_region_shapes=resources("raw_region_shapes.geojson")
+        raw_region_shapes=resources("raw_region_shapes.geojson"),
     log:
-        logs("raw_region_shapes.log")
+        logs("raw_region_shapes.log"),
     resources:
         mem_mb=1000,
     conda:
@@ -49,7 +52,7 @@ rule manual_region_merger:
     output:
         merged_shapes=resources("merged_shapes.geojson"),
     log:
-        logs("manual_region_merger.log")
+        logs("manual_region_merger.log"),
     resources:
         mem_mb=1000,
     conda:
@@ -61,10 +64,10 @@ rule manual_region_merger:
 # Rule to retrieve generation unit unavailability data from ENTSO-E
 rule retrieve_unavailability_data:
     output:
-        gb_planned_unavailability=resources("gb_planned_unavailability.csv"),
-        gb_forced_unavailability=resources("gb_forced_unavailability.csv"),
+        planned_unavailability=resources("planned_unavailability.csv"),
+        forced_unavailability=resources("forced_unavailability.csv"),
     log:
-        logs("retrieve_unavailability_data.log")
+        logs("retrieve_unavailability_data.log"),
     resources:
         mem_mb=2000,
     conda:

--- a/scripts/gb-model/retrieve_unavailability_data.py
+++ b/scripts/gb-model/retrieve_unavailability_data.py
@@ -521,9 +521,14 @@ def process_unavailability_data(
     df["bidding_zone"] = bidding_zone
 
     # Clean and process data
+    entso_e_config = config.get("unavailability", {}).get("entso_e", {})
     business_type_map = {
-        config["business_types"]["planned"]: "Planned maintenance",
-        config["business_types"]["forced"]: "Forced unavailability",
+        entso_e_config.get("business_types", {}).get(
+            "planned", "A53"
+        ): "Planned maintenance",
+        entso_e_config.get("business_types", {}).get(
+            "forced", "A54"
+        ): "Forced unavailability",
     }
     df["business_type_desc"] = df["business_type"].map(business_type_map)
 
@@ -650,23 +655,19 @@ if __name__ == "__main__":
         )
 
     # Get date parameters from config or use defaults
-    start_date = pd.to_datetime(
-        snakemake.config.get("unavailability_start_date", "2023-01-01")
-    )
-    end_date = pd.to_datetime(
-        snakemake.config.get("unavailability_end_date", "2023-12-31")
-    )
+    unavailability_config = snakemake.config.get("unavailability", {})
+    start_date = pd.to_datetime(unavailability_config.get("start_date", "2023-01-01"))
+    end_date = pd.to_datetime(unavailability_config.get("end_date", "2023-12-31"))
 
-    bidding_zones = snakemake.config.get("unavailability_bidding_zones", ["GB"])
-    business_types = snakemake.config.get(
-        "unavailability_business_types", ["planned", "forced"]
-    )
-    max_request_days = snakemake.config.get("max_request_days", 7)
+    bidding_zones = unavailability_config.get("bidding_zones", ["GB"])
+    business_types = unavailability_config.get("business_types", ["planned", "forced"])
+    max_request_days = unavailability_config.get("max_request_days", 7)
 
     # Get mapping dictionaries from config
-    uk_bidding_zones = snakemake.config.get("uk_bidding_zones", {})
-    business_types_map = snakemake.config.get("business_types", {})
-    doc_status_map = snakemake.config.get("doc_status", {})
+    entso_e_config = unavailability_config.get("entso_e", {})
+    uk_bidding_zones = entso_e_config.get("bidding_zones", {})
+    business_types_map = entso_e_config.get("business_types", {})
+    doc_status_map = entso_e_config.get("doc_status", {})
 
     # Initialize API client
     api_client = ENTSOEUnavailabilityAPI(api_key)

--- a/scripts/gb-model/retrieve_unavailability_data.py
+++ b/scripts/gb-model/retrieve_unavailability_data.py
@@ -1,0 +1,779 @@
+# SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Retrieve Generation Unit Unavailability Data from ENTSO-E Transparency Platform
+
+This script retrieves generation unit unavailability data from the ENTSO-E API
+for the UK bidding zones and processes it for use in PyPSA modeling.
+
+API Documentation: 15.1.A&B Unavailability of Generation Units
+"""
+
+import requests
+import pandas as pd
+import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta
+import logging
+from pathlib import Path
+from typing import Optional, Dict, List, Any
+import time
+import os
+from dotenv import load_dotenv
+import zipfile
+import io
+import shutil
+
+from scripts._helpers import configure_logging, set_scenario_config
+
+logger = logging.getLogger(__name__)
+
+# UK bidding zone codes
+UK_BIDDING_ZONES = {
+    "GB": "10YGB----------A",  # Great Britain
+}
+
+# Business types for outage classification
+BUSINESS_TYPES = {
+    "planned": "A53",      # Planned maintenance
+    "forced": "A54"        # Forced unavailability (unplanned outage)
+}
+
+# Document status codes
+DOC_STATUS = {
+    "active": "A05",       # Active
+    "cancelled": "A09",    # Cancelled
+    "withdrawn": "A13"     # Withdrawn
+}
+
+
+class ENTSOEUnavailabilityAPI:
+    """
+    Interface to ENTSO-E Transparency Platform API for unavailability data
+    """
+    
+    def __init__(self, api_key: str):
+        """
+        Initialize the API client
+        
+        Args:
+            api_key: ENTSO-E API key for authentication
+        """
+        self.api_key = api_key
+        self.base_url = "https://web-api.tp.entsoe.eu/api"
+        self.session = requests.Session()
+        self.rate_limit_delay = 1.0  # Seconds between requests
+        
+    def _make_request(self, params: Dict[str, Any]) -> requests.Response:
+        """
+        Make API request with rate limiting and error handling
+        
+        Args:
+            params: Query parameters for the API request
+            
+        Returns:
+            Response object
+        """
+        # Add API key to parameters
+        params["securityToken"] = self.api_key
+        
+        logger.debug(f"Making API request with params: {params}")
+        
+        try:
+            # Rate limiting
+            time.sleep(self.rate_limit_delay)
+            
+            response = self.session.get(self.base_url, params=params, timeout=30)
+            logger.debug(f"API response status: {response.status_code}")
+            logger.debug(f"API response length: {len(response.content)} bytes")
+            
+            if response.status_code != 200:
+                logger.error(f"API returned status {response.status_code}")
+                
+            response.raise_for_status()
+            return response
+            
+        except requests.exceptions.RequestException as e:
+            logger.error(f"API request failed: {e}")
+            raise
+    
+    def get_unavailability_data(
+        self,
+        bidding_zone: str,
+        period_start: datetime,
+        period_end: datetime,
+        business_type: Optional[str] = None,
+        doc_status: Optional[str] = None,
+        registered_resource: Optional[str] = None,
+        offset: int = 0
+    ) -> bytes:
+        """
+        Retrieve unavailability data from ENTSO-E API
+        
+        Args:
+            bidding_zone: EIC code for bidding zone (e.g., '10YGB----------A' for GB)
+            period_start: Start datetime for the query period
+            period_end: End datetime for the query period
+            business_type: Optional business type ('A53' for planned, 'A54' for forced)
+            doc_status: Optional document status ('A05', 'A09', 'A13')
+            registered_resource: Optional EIC code of specific generation unit
+            offset: Offset for pagination (0-4800)
+            
+        Returns:
+            Raw response content as bytes (could be XML or ZIP)
+        """
+        params = {
+            "documentType": "A80",  # Generation unavailability
+            "BiddingZone_Domain": bidding_zone,
+            "periodStart": period_start.strftime("%Y%m%d%H%M"),
+            "periodEnd": period_end.strftime("%Y%m%d%H%M"),
+        }
+        
+        # Add optional parameters
+        if business_type:
+            params["BusinessType"] = business_type
+        if doc_status:
+            params["DocStatus"] = doc_status
+        if registered_resource:
+            params["RegisteredResource"] = registered_resource
+        if offset > 0:
+            params["offset"] = offset
+            
+        response = self._make_request(params)
+        return response.content
+
+
+def generate_weekly_periods(start_date: datetime, end_date: datetime, max_days: int = 7) -> List[tuple]:
+    """
+    Generate weekly periods for API requests to stay within API limits
+    
+    Args:
+        start_date: Overall start date
+        end_date: Overall end date
+        max_days: Maximum days per request (default: 7)
+        
+    Returns:
+        List of (start, end) datetime tuples for each period
+    """
+    periods = []
+    current_start = start_date
+    
+    while current_start < end_date:
+        current_end = min(current_start + timedelta(days=max_days), end_date)
+        periods.append((current_start, current_end))
+        current_start = current_end
+    
+    logger.info(f"Split {start_date.date()} to {end_date.date()} into {len(periods)} weekly periods")
+    return periods
+
+
+def retrieve_data_by_periods(
+    api_client,
+    bidding_zone: str,
+    periods: List[tuple],
+    business_type: str,
+    doc_status: str,
+    xml_save_dir: str
+) -> List[pd.DataFrame]:
+    """
+    Retrieve data for multiple periods and return list of DataFrames
+    
+    Args:
+        api_client: ENTSOEUnavailabilityAPI instance
+        bidding_zone: EIC code for bidding zone
+        periods: List of (start, end) datetime tuples
+        business_type: Business type code
+        doc_status: Document status code
+        xml_save_dir: Directory to save XML files
+        
+    Returns:
+        List of DataFrames, one per period
+    """
+    all_dataframes = []
+    
+    for i, (period_start, period_end) in enumerate(periods, 1):
+        logger.info(f"Retrieving period {i}/{len(periods)}: {period_start.date()} to {period_end.date()}")
+        
+        try:
+            # Add period identifier to XML save directory
+            period_xml_dir = f"{xml_save_dir}/period_{period_start.strftime('%Y%m%d')}_{period_end.strftime('%Y%m%d')}"
+            
+            response_content = api_client.get_unavailability_data(
+                bidding_zone=bidding_zone,
+                period_start=period_start,
+                period_end=period_end,
+                business_type=business_type,
+                doc_status=doc_status
+            )
+            
+            logger.debug(f"Retrieved {len(response_content)} bytes for period {i}")
+            
+            # Parse data and save XML files
+            df = parse_unavailability_zip(response_content, period_xml_dir)
+            
+            if not df.empty:
+                # Add period metadata
+                df['request_period_start'] = period_start
+                df['request_period_end'] = period_end
+                df['period_batch'] = i
+                all_dataframes.append(df)
+                logger.info(f"Period {i}: Parsed {len(df)} records")
+            else:
+                logger.info(f"Period {i}: No data found")
+            
+            # Rate limiting between requests
+            if i < len(periods):
+                time.sleep(2)  # 2 second delay between requests
+                
+        except Exception as e:
+            logger.error(f"Failed to retrieve period {i} ({period_start.date()} to {period_end.date()}): {e}")
+            continue
+    
+    logger.info(f"Successfully retrieved {len(all_dataframes)} periods out of {len(periods)}")
+    return all_dataframes
+
+
+def merge_period_dataframes(dataframes: List[pd.DataFrame]) -> pd.DataFrame:
+    """
+    Merge DataFrames from multiple periods and remove duplicates
+    
+    Args:
+        dataframes: List of DataFrames to merge
+        
+    Returns:
+        Combined DataFrame with duplicates removed
+    """
+    if not dataframes:
+        logger.warning("No dataframes to merge")
+        return pd.DataFrame()
+    
+    # Combine all dataframes
+    combined_df = pd.concat(dataframes, ignore_index=True)
+    logger.info(f"Combined {len(dataframes)} periods into {len(combined_df)} total records")
+    
+    # Remove duplicates based on key fields
+    # Use document_mrid and start_time/end_time as the primary key for deduplication
+    # This focuses on actual outage periods rather than data reporting periods
+    key_columns = ['document_mrid', 'timeseries_mrid', 'start_time', 'end_time']
+    
+    # Only use columns that exist in the dataframe
+    existing_key_columns = [col for col in key_columns if col in combined_df.columns]
+    
+    # If start_time/end_time not available, fall back to period_start/period_end
+    if 'start_time' not in existing_key_columns and 'period_start' in combined_df.columns:
+        key_columns = ['document_mrid', 'timeseries_mrid', 'period_start', 'period_end']
+        existing_key_columns = [col for col in key_columns if col in combined_df.columns]
+    
+    if existing_key_columns:
+        initial_count = len(combined_df)
+        combined_df = combined_df.drop_duplicates(subset=existing_key_columns, keep='first')
+        removed_count = initial_count - len(combined_df)
+        
+        if removed_count > 0:
+            logger.info(f"Removed {removed_count} duplicate records, {len(combined_df)} records remaining")
+    
+    # Sort by start time and resource name
+    if 'start_time' in combined_df.columns:
+        combined_df = combined_df.sort_values(['start_time', 'resource_name'])
+    elif 'period_start' in combined_df.columns:
+        combined_df = combined_df.sort_values(['period_start', 'resource_name'])
+    
+    return combined_df
+
+
+def parse_unavailability_zip(zip_content: bytes, save_xml_dir: Optional[str] = None) -> pd.DataFrame:
+    """
+    Parse ZIP file containing XML unavailability data
+    
+    Args:
+        zip_content: ZIP file content as bytes
+        save_xml_dir: Optional directory to save extracted XML files
+        
+    Returns:
+        DataFrame with parsed unavailability data
+    """
+    outages = []
+    
+    try:
+        with zipfile.ZipFile(io.BytesIO(zip_content)) as zf:
+            xml_files = [f for f in zf.namelist() if f.endswith('.xml')]
+            logger.info(f"Processing ZIP file with {len(xml_files)} XML files")
+            
+            # Create save directory if specified
+            if save_xml_dir:
+                save_path = Path(save_xml_dir)
+                save_path.mkdir(parents=True, exist_ok=True)
+                logger.info(f"Saving XML files to: {save_path}")
+            
+            for filename in xml_files:
+                try:
+                    xml_content = zf.read(filename).decode('utf-8')
+                    
+                    # Save XML file if directory specified
+                    if save_xml_dir:
+                        xml_file_path = save_path / filename
+                        with open(xml_file_path, 'w', encoding='utf-8') as f:
+                            f.write(xml_content)
+                        logger.debug(f"Saved {filename} to {xml_file_path}")
+                    
+                    file_outages = parse_xml_content(xml_content, filename)
+                    outages.extend(file_outages)
+                    
+                except Exception as e:
+                    logger.error(f"Error processing {filename}: {e}")
+                    continue
+                    
+    except zipfile.BadZipFile as e:
+        logger.error(f"Invalid ZIP file: {e}")
+        return pd.DataFrame()
+    
+    if not outages:
+        logger.warning("No outage data found in ZIP file")
+        return pd.DataFrame()
+    
+    df = pd.DataFrame(outages)
+    logger.info(f"Parsed {len(df)} outage records from ZIP file")
+    return df
+
+
+def parse_xml_content(xml_content: str, filename: str = "") -> List[Dict]:
+    """
+    Parse individual XML content for unavailability data
+    
+    Args:
+        xml_content: XML content as string
+        filename: Optional filename for logging
+        
+    Returns:
+        List of outage dictionaries
+    """
+    outages = []
+    
+    try:
+        root = ET.fromstring(xml_content)
+        namespaces = {'ns': 'urn:iec62325.351:tc57wg16:451-6:outagedocument:3:0'}
+        
+        # Extract document-level information
+        doc_mrid = _get_text(root, './/ns:mRID', namespaces)
+        doc_revision = _get_text(root, './/ns:revisionNumber', namespaces)
+        doc_status = _get_text(root, './/ns:docStatus/ns:value', namespaces)
+        
+        # Find all TimeSeries elements
+        timeseries_elements = root.findall('.//ns:TimeSeries', namespaces)
+        
+        for ts in timeseries_elements:
+            outage_data = {}
+            
+            # Document information
+            outage_data['document_mrid'] = doc_mrid
+            outage_data['revision_number'] = doc_revision
+            outage_data['doc_status'] = doc_status
+            outage_data['source_file'] = filename
+            
+            # TimeSeries information
+            outage_data['timeseries_mrid'] = _get_text(ts, './/ns:mRID', namespaces)
+            outage_data['business_type'] = _get_text(ts, './/ns:businessType', namespaces)
+            outage_data['bidding_zone'] = _get_text(ts, './/ns:biddingZone_Domain.mRID', namespaces)
+            
+            # Resource information
+            outage_data['resource_mrid'] = _get_text(ts, './/ns:production_RegisteredResource.mRID', namespaces)
+            outage_data['resource_name'] = _get_text(ts, './/ns:production_RegisteredResource.name', namespaces)
+            outage_data['resource_location'] = _get_text(ts, './/ns:production_RegisteredResource.location.name', namespaces)
+            outage_data['resource_type'] = _get_text(ts, './/ns:production_RegisteredResource.pSRType.psrType', namespaces)
+            
+            # Power system resource details
+            outage_data['psr_mrid'] = _get_text(ts, './/ns:production_RegisteredResource.pSRType.powerSystemResources.mRID', namespaces)
+            outage_data['psr_name'] = _get_text(ts, './/ns:production_RegisteredResource.pSRType.powerSystemResources.name', namespaces)
+            nominal_power = _get_text(ts, './/ns:production_RegisteredResource.pSRType.powerSystemResources.nominalP', namespaces)
+            outage_data['nominal_power_mw'] = float(nominal_power) if nominal_power else None
+            
+            # Time periods from TimeSeries level
+            start_date = _get_text(ts, './/ns:start_DateAndOrTime.date', namespaces)
+            start_time = _get_text(ts, './/ns:start_DateAndOrTime.time', namespaces)
+            end_date = _get_text(ts, './/ns:end_DateAndOrTime.date', namespaces)
+            end_time = _get_text(ts, './/ns:end_DateAndOrTime.time', namespaces)
+            
+            if start_date and start_time:
+                outage_data['start_time'] = pd.to_datetime(f"{start_date} {start_time}")
+            if end_date and end_time:
+                outage_data['end_time'] = pd.to_datetime(f"{end_date} {end_time}")
+            
+            # Process Available_Period elements
+            available_periods = ts.findall('.//ns:Available_Period', namespaces)
+            
+            if available_periods:
+                for period in available_periods:
+                    period_data = outage_data.copy()
+                    
+                    # Period-specific time interval
+                    interval_start = _get_text(period, './/ns:timeInterval/ns:start', namespaces)
+                    interval_end = _get_text(period, './/ns:timeInterval/ns:end', namespaces)
+                    
+                    if interval_start:
+                        period_data['period_start'] = pd.to_datetime(interval_start)
+                    if interval_end:
+                        period_data['period_end'] = pd.to_datetime(interval_end)
+                    
+                    # Resolution
+                    period_data['resolution'] = _get_text(period, './/ns:resolution', namespaces)
+                    
+                    # Extract data points
+                    points = period.findall('.//ns:Point', namespaces)
+                    if points:
+                        quantities = []
+                        for point in points:
+                            qty = _get_text(point, './/ns:quantity', namespaces)
+                            if qty:
+                                quantities.append(float(qty))
+                        
+                        if quantities:
+                            period_data['min_available_mw'] = min(quantities)
+                            period_data['max_available_mw'] = max(quantities)
+                            period_data['avg_available_mw'] = sum(quantities) / len(quantities)
+                            period_data['num_data_points'] = len(quantities)
+                            
+                            # Calculate unavailable capacity
+                            if outage_data['nominal_power_mw']:
+                                period_data['min_unavailable_mw'] = max(0, outage_data['nominal_power_mw'] - max(quantities))
+                                period_data['max_unavailable_mw'] = max(0, outage_data['nominal_power_mw'] - min(quantities))
+                    
+                    outages.append(period_data)
+            else:
+                # No Available_Period elements, just add the TimeSeries data
+                outages.append(outage_data)
+                
+    except ET.ParseError as e:
+        logger.error(f"Failed to parse XML {filename}: {e}")
+    except Exception as e:
+        logger.error(f"Error processing XML {filename}: {e}")
+    
+    return outages
+
+
+def _get_text(element, xpath: str, namespaces: Dict[str, str]) -> Optional[str]:
+    """
+    Helper function to safely extract text from XML element
+    
+    Args:
+        element: XML element
+        xpath: XPath expression
+        namespaces: XML namespaces
+        
+    Returns:
+        Text content or None
+    """
+    found = element.find(xpath, namespaces)
+    return found.text if found is not None else None
+
+
+def process_unavailability_data(
+    df: pd.DataFrame,
+    output_file: str,
+    bidding_zone: str
+) -> None:
+    """
+    Process and save unavailability data
+    
+    Args:
+        df: DataFrame with raw unavailability data
+        output_file: Path to save processed data
+        bidding_zone: Bidding zone identifier
+    """
+    if df.empty:
+        logger.warning("No data to process")
+        # Create empty CSV with headers
+        empty_df = pd.DataFrame(columns=[
+            'document_mrid', 'resource_mrid', 'resource_name', 'resource_location',
+            'resource_type', 'business_type', 'doc_status',
+            'start_time', 'end_time', 'period_start', 'period_end',
+            'nominal_power_mw', 'min_available_mw', 'max_available_mw', 'avg_available_mw',
+            'min_unavailable_mw', 'max_unavailable_mw',
+            'bidding_zone'
+        ])
+        empty_df.to_csv(output_file, index=False)
+        return
+    
+    # Add bidding zone information
+    df['bidding_zone'] = bidding_zone
+    
+    # Clean and process data
+    df['business_type_desc'] = df['business_type'].map({
+        'A53': 'Planned maintenance',
+        'A54': 'Forced unavailability'
+    })
+    
+    df['doc_status_desc'] = df['doc_status'].map({
+        'A05': 'Active',
+        'A09': 'Cancelled',
+        'A13': 'Withdrawn'
+    })
+    
+    # Sort by start time
+    df = df.sort_values(['start_time', 'resource_name'])
+    
+    # Save processed data
+    df.to_csv(output_file, index=False)
+    logger.info(f"Saved {len(df)} records to {output_file}")
+    
+    # Print summary statistics
+    logger.info("Data summary:")
+    if 'start_time' in df.columns and not df['start_time'].isnull().all():
+        logger.info(f"  Date range: {df['start_time'].min()} to {df['end_time'].max()}")
+    logger.info(f"  Total outage records: {len(df)}")
+    logger.info(f"  Unique generation units: {df['resource_name'].nunique()}")
+    
+    if 'nominal_power_mw' in df.columns and not df['nominal_power_mw'].isnull().all():
+        logger.info(f"  Total installed capacity: {df['nominal_power_mw'].sum():.1f} MW")
+    
+    # Business type breakdown
+    if 'business_type_desc' in df.columns:
+        business_breakdown = df.groupby('business_type_desc').agg({
+            'resource_name': 'nunique',
+            'document_mrid': 'count'
+        }).round(1)
+        business_breakdown.columns = ['Unique_Units', 'Total_Records']
+        logger.info(f"  Breakdown by type:\\n{business_breakdown}")
+
+
+def create_xml_index(xml_dir: str) -> pd.DataFrame:
+    """
+    Create an index of stored XML files with metadata
+    
+    Args:
+        xml_dir: Directory containing XML files
+        
+    Returns:
+        DataFrame with XML file metadata
+    """
+    xml_path = Path(xml_dir)
+    if not xml_path.exists():
+        return pd.DataFrame()
+    
+    xml_files = list(xml_path.glob('*.xml'))
+    if not xml_files:
+        return pd.DataFrame()
+    
+    index_data = []
+    
+    for xml_file in xml_files:
+        try:
+            # Extract metadata from filename
+            filename = xml_file.name
+            
+            # Parse basic file info
+            file_info = {
+                'filename': filename,
+                'filepath': str(xml_file),
+                'size_bytes': xml_file.stat().st_size,
+                'modified_time': datetime.fromtimestamp(xml_file.stat().st_mtime)
+            }
+            
+            # Try to extract period from filename
+            if 'PLANNED_UNAVAIL_OF_GENERATION_UNITS_' in filename:
+                parts = filename.split('PLANNED_UNAVAIL_OF_GENERATION_UNITS_')[1].replace('.xml', '')
+                if '-' in parts:
+                    start_str, end_str = parts.split('-')
+                    try:
+                        file_info['period_start'] = pd.to_datetime(start_str, format='%Y%m%d%H%M')
+                        file_info['period_end'] = pd.to_datetime(end_str, format='%Y%m%d%H%M')
+                    except:
+                        pass
+            
+            index_data.append(file_info)
+            
+        except Exception as e:
+            logger.warning(f"Error indexing {xml_file}: {e}")
+            continue
+    
+    if index_data:
+        df = pd.DataFrame(index_data)
+        # Save index file
+        index_file = xml_path / 'xml_index.csv'
+        df.to_csv(index_file, index=False)
+        logger.info(f"Created XML index with {len(df)} files: {index_file}")
+        return df
+    
+    return pd.DataFrame()
+
+
+def cleanup_xml_storage(base_dir: str = "data/gb-model/outage_data", max_age_days: int = 30):
+    """
+    Clean up old XML files to manage storage space
+    
+    Args:
+        base_dir: Base directory for XML storage
+        max_age_days: Maximum age of files to keep
+    """
+    base_path = Path(base_dir)
+    if not base_path.exists():
+        return
+    
+    cutoff_time = datetime.now() - timedelta(days=max_age_days)
+    deleted_count = 0
+    deleted_size = 0
+    
+    for xml_file in base_path.rglob('*.xml'):
+        try:
+            if datetime.fromtimestamp(xml_file.stat().st_mtime) < cutoff_time:
+                file_size = xml_file.stat().st_size
+                xml_file.unlink()
+                deleted_count += 1
+                deleted_size += file_size
+        except Exception as e:
+            logger.warning(f"Error deleting {xml_file}: {e}")
+    
+    if deleted_count > 0:
+        logger.info(f"Cleaned up {deleted_count} old XML files ({deleted_size/1024/1024:.1f} MB)")
+
+
+def test_api_connection(api_client, zone_code: str) -> bool:
+    """
+    Test API connection with a small date range
+    
+    Args:
+        api_client: ENTSOEUnavailabilityAPI instance
+        zone_code: EIC code for bidding zone
+        
+    Returns:
+        True if API connection works
+    """
+    try:
+        # Test with a recent date range
+        test_start = datetime.now() - timedelta(days=30)
+        test_end = datetime.now() - timedelta(days=29)
+        
+        logger.info(f"Testing API connection with date range: {test_start.date()} to {test_end.date()}")
+        
+        response_content = api_client.get_unavailability_data(
+            bidding_zone=zone_code,
+            period_start=test_start,
+            period_end=test_end,
+            business_type="A53",  # Planned maintenance
+        )
+        
+        logger.info(f"Test API response length: {len(response_content)} bytes")
+        
+        # Check if it's a ZIP file
+        is_zip = response_content.startswith(b'PK')
+        logger.info(f"Response is ZIP format: {is_zip}")
+        
+        return True
+        
+    except Exception as e:
+        logger.error(f"API connection test failed: {e}")
+        return False
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from scripts._helpers import mock_snakemake
+        snakemake = mock_snakemake("retrieve_unavailability_data")
+    
+    configure_logging(snakemake)
+    set_scenario_config(snakemake)
+    
+    # Load environment variables from .env file
+    load_dotenv()
+    
+    # Get API key from environment variable
+    api_key = os.getenv("ENTSO_E_API_KEY")
+    
+    if not api_key:
+        raise ValueError(
+            "ENTSO-E API key not found. Please set ENTSO_E_API_KEY in your .env file or environment variables.\\n"
+            "You can get an API key from: https://transparency.entsoe.eu/usrm/user/createPublicApiUser.do"
+        )
+    
+    # Get date parameters from config or use defaults
+    start_date = pd.to_datetime(snakemake.config.get("unavailability_start_date", "2023-01-01"))
+    end_date = pd.to_datetime(snakemake.config.get("unavailability_end_date", "2023-12-31"))
+    
+    bidding_zones = snakemake.config.get("unavailability_bidding_zones", ["GB"])
+    business_types = snakemake.config.get("unavailability_business_types", ["planned", "forced"])
+    max_request_days = snakemake.config.get("max_request_days", 7)
+    
+    logger.info(f"Configuration loaded:")
+    logger.info(f"  Date range: {start_date.date()} to {end_date.date()}")
+    logger.info(f"  Bidding zones: {bidding_zones}")
+    logger.info(f"  Business types: {business_types}")
+    logger.info(f"  Max request days: {max_request_days}")
+    
+    # Initialize API client
+    api_client = ENTSOEUnavailabilityAPI(api_key)
+    
+    # Test API connection first
+    logger.info("Testing API connection...")
+    if not test_api_connection(api_client, UK_BIDDING_ZONES["GB"]):
+        raise ConnectionError("API connection test failed. Check your API key and network connection.")
+    
+    # Process each bidding zone
+    for zone in bidding_zones:
+        if zone not in UK_BIDDING_ZONES:
+            logger.warning(f"Unknown bidding zone: {zone}")
+            continue
+            
+        zone_code = UK_BIDDING_ZONES[zone]
+        logger.info(f"Retrieving unavailability data for {zone} ({zone_code})")
+        
+        # Process each business type
+        for business_type in business_types:
+            if business_type not in BUSINESS_TYPES:
+                logger.warning(f"Unknown business type: {business_type}")
+                continue
+                
+            business_code = BUSINESS_TYPES[business_type]
+            logger.info(f"Processing {business_type} outages ({business_code})")
+            
+            try:
+                # Split the date range into weekly periods
+                periods = generate_weekly_periods(start_date, end_date, max_days=max_request_days)
+                
+                # Create XML storage directory
+                xml_save_dir = f"data/gb-model/outage_data/{zone.lower()}_{business_type}"
+                
+                # Retrieve data for all periods
+                all_dataframes = retrieve_data_by_periods(
+                    api_client=api_client,
+                    bidding_zone=zone_code,
+                    periods=periods,
+                    business_type=business_code,
+                    doc_status=DOC_STATUS["active"],
+                    xml_save_dir=xml_save_dir
+                )
+                
+                # Merge all periods into a single DataFrame
+                df = merge_period_dataframes(all_dataframes)
+                logger.info(f"Final merged DataFrame has {len(df)} rows")
+                
+                # Generate output filename
+                output_file = snakemake.output[f"{zone.lower()}_{business_type}_unavailability"]
+                
+                # Process and save data
+                process_unavailability_data(df, output_file, zone)
+                
+                # Log XML storage information across all periods
+                xml_base_dir = Path(xml_save_dir)
+                if xml_base_dir.exists():
+                    # Count XML files across all period subdirectories
+                    total_xml_count = len(list(xml_base_dir.rglob('*.xml')))
+                    total_size = sum(f.stat().st_size for f in xml_base_dir.rglob('*.xml'))
+                    
+                    period_dirs = [d for d in xml_base_dir.iterdir() if d.is_dir() and d.name.startswith('period_')]
+                    
+                    logger.info(f"Stored {total_xml_count} XML files ({total_size/1024/1024:.1f} MB) across {len(period_dirs)} periods in {xml_base_dir}")
+                    
+                    # Create XML index for the overall collection
+                    create_xml_index(xml_save_dir)
+                
+            except Exception as e:
+                logger.error(f"Failed to process {zone} {business_type} data: {e}")
+                logger.exception("Full traceback:")
+                continue
+    
+    # Clean up old XML files if configured
+    cleanup_days = snakemake.config.get("xml_cleanup_days", 30)
+    if cleanup_days > 0:
+        cleanup_xml_storage(max_age_days=cleanup_days)
+    
+    logger.info("Unavailability data retrieval completed")

--- a/scripts/gb-model/retrieve_unavailability_data.py
+++ b/scripts/gb-model/retrieve_unavailability_data.py
@@ -1,6 +1,6 @@
-# SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+# SPDX-FileCopyrightText:  gb-open-market-model contributors
 #
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-License-Identifier: MIT
 
 """
 Retrieve Generation Unit Unavailability Data from ENTSO-E Transparency Platform
@@ -11,19 +11,19 @@ for the UK bidding zones and processes it for use in PyPSA modeling.
 API Documentation: 15.1.A&B Unavailability of Generation Units
 """
 
-import requests
-import pandas as pd
-import xml.etree.ElementTree as ET
-from datetime import datetime, timedelta
-import logging
-from pathlib import Path
-from typing import Optional, Dict, List, Any
-import time
-import os
-from dotenv import load_dotenv
-import zipfile
 import io
-import shutil
+import logging
+import os
+import time
+import xml.etree.ElementTree as ET
+import zipfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+import requests
+from dotenv import load_dotenv
 
 from scripts._helpers import configure_logging, set_scenario_config
 
@@ -36,15 +36,15 @@ UK_BIDDING_ZONES = {
 
 # Business types for outage classification
 BUSINESS_TYPES = {
-    "planned": "A53",      # Planned maintenance
-    "forced": "A54"        # Forced unavailability (unplanned outage)
+    "planned": "A53",  # Planned maintenance
+    "forced": "A54",  # Forced unavailability (unplanned outage)
 }
 
 # Document status codes
 DOC_STATUS = {
-    "active": "A05",       # Active
-    "cancelled": "A09",    # Cancelled
-    "withdrawn": "A13"     # Withdrawn
+    "active": "A05",  # Active
+    "cancelled": "A09",  # Cancelled
+    "withdrawn": "A13",  # Withdrawn
 }
 
 
@@ -52,52 +52,52 @@ class ENTSOEUnavailabilityAPI:
     """
     Interface to ENTSO-E Transparency Platform API for unavailability data
     """
-    
+
     def __init__(self, api_key: str):
         """
         Initialize the API client
-        
+
         Args:
             api_key: ENTSO-E API key for authentication
         """
         self.api_key = api_key
         self.base_url = "https://web-api.tp.entsoe.eu/api"
         self.session = requests.Session()
-        self.rate_limit_delay = 1.0  # Seconds between requests
-        
-    def _make_request(self, params: Dict[str, Any]) -> requests.Response:
+        self.rate_limit_delay = 3.0  # Seconds between requests
+
+    def _make_request(self, params: dict[str, Any]) -> requests.Response:
         """
         Make API request with rate limiting and error handling
-        
+
         Args:
             params: Query parameters for the API request
-            
+
         Returns:
             Response object
         """
         # Add API key to parameters
         params["securityToken"] = self.api_key
-        
+
         logger.debug(f"Making API request with params: {params}")
-        
+
         try:
             # Rate limiting
             time.sleep(self.rate_limit_delay)
-            
+
             response = self.session.get(self.base_url, params=params, timeout=30)
             logger.debug(f"API response status: {response.status_code}")
             logger.debug(f"API response length: {len(response.content)} bytes")
-            
+
             if response.status_code != 200:
                 logger.error(f"API returned status {response.status_code}")
-                
+
             response.raise_for_status()
             return response
-            
+
         except requests.exceptions.RequestException as e:
             logger.error(f"API request failed: {e}")
             raise
-    
+
     def get_unavailability_data(
         self,
         bidding_zone: str,
@@ -106,11 +106,11 @@ class ENTSOEUnavailabilityAPI:
         business_type: Optional[str] = None,
         doc_status: Optional[str] = None,
         registered_resource: Optional[str] = None,
-        offset: int = 0
+        offset: int = 0,
     ) -> bytes:
         """
         Retrieve unavailability data from ENTSO-E API
-        
+
         Args:
             bidding_zone: EIC code for bidding zone (e.g., '10YGB----------A' for GB)
             period_start: Start datetime for the query period
@@ -119,7 +119,7 @@ class ENTSOEUnavailabilityAPI:
             doc_status: Optional document status ('A05', 'A09', 'A13')
             registered_resource: Optional EIC code of specific generation unit
             offset: Offset for pagination (0-4800)
-            
+
         Returns:
             Raw response content as bytes (could be XML or ZIP)
         """
@@ -129,7 +129,7 @@ class ENTSOEUnavailabilityAPI:
             "periodStart": period_start.strftime("%Y%m%d%H%M"),
             "periodEnd": period_end.strftime("%Y%m%d%H%M"),
         }
-        
+
         # Add optional parameters
         if business_type:
             params["BusinessType"] = business_type
@@ -139,46 +139,50 @@ class ENTSOEUnavailabilityAPI:
             params["RegisteredResource"] = registered_resource
         if offset > 0:
             params["offset"] = offset
-            
+
         response = self._make_request(params)
         return response.content
 
 
-def generate_weekly_periods(start_date: datetime, end_date: datetime, max_days: int = 7) -> List[tuple]:
+def generate_weekly_periods(
+    start_date: datetime, end_date: datetime, max_days: int = 7
+) -> list[tuple]:
     """
     Generate weekly periods for API requests to stay within API limits
-    
+
     Args:
         start_date: Overall start date
         end_date: Overall end date
         max_days: Maximum days per request (default: 7)
-        
+
     Returns:
         List of (start, end) datetime tuples for each period
     """
     periods = []
     current_start = start_date
-    
+
     while current_start < end_date:
         current_end = min(current_start + timedelta(days=max_days), end_date)
         periods.append((current_start, current_end))
         current_start = current_end
-    
-    logger.info(f"Split {start_date.date()} to {end_date.date()} into {len(periods)} weekly periods")
+
+    logger.info(
+        f"Split {start_date.date()} to {end_date.date()} into {len(periods)} weekly periods"
+    )
     return periods
 
 
 def retrieve_data_by_periods(
     api_client,
     bidding_zone: str,
-    periods: List[tuple],
+    periods: list[tuple],
     business_type: str,
     doc_status: str,
-    xml_save_dir: str
-) -> List[pd.DataFrame]:
+    xml_save_dir: str,
+) -> list[pd.DataFrame]:
     """
     Retrieve data for multiple periods and return list of DataFrames
-    
+
     Args:
         api_client: ENTSOEUnavailabilityAPI instance
         bidding_zone: EIC code for bidding zone
@@ -186,280 +190,337 @@ def retrieve_data_by_periods(
         business_type: Business type code
         doc_status: Document status code
         xml_save_dir: Directory to save XML files
-        
+
     Returns:
         List of DataFrames, one per period
     """
     all_dataframes = []
-    
+
     for i, (period_start, period_end) in enumerate(periods, 1):
-        logger.info(f"Retrieving period {i}/{len(periods)}: {period_start.date()} to {period_end.date()}")
-        
+        logger.info(
+            f"Retrieving period {i}/{len(periods)}: {period_start.date()} to {period_end.date()}"
+        )
+
         try:
             # Add period identifier to XML save directory
             period_xml_dir = f"{xml_save_dir}/period_{period_start.strftime('%Y%m%d')}_{period_end.strftime('%Y%m%d')}"
-            
+
             response_content = api_client.get_unavailability_data(
                 bidding_zone=bidding_zone,
                 period_start=period_start,
                 period_end=period_end,
                 business_type=business_type,
-                doc_status=doc_status
+                doc_status=doc_status,
             )
-            
+
             logger.debug(f"Retrieved {len(response_content)} bytes for period {i}")
-            
+
             # Parse data and save XML files
             df = parse_unavailability_zip(response_content, period_xml_dir)
-            
+
             if not df.empty:
                 # Add period metadata
-                df['request_period_start'] = period_start
-                df['request_period_end'] = period_end
-                df['period_batch'] = i
+                df["request_period_start"] = period_start
+                df["request_period_end"] = period_end
+                df["period_batch"] = i
                 all_dataframes.append(df)
                 logger.info(f"Period {i}: Parsed {len(df)} records")
             else:
                 logger.info(f"Period {i}: No data found")
-            
+
             # Rate limiting between requests
             if i < len(periods):
                 time.sleep(2)  # 2 second delay between requests
-                
+
         except Exception as e:
-            logger.error(f"Failed to retrieve period {i} ({period_start.date()} to {period_end.date()}): {e}")
+            logger.error(
+                f"Failed to retrieve period {i} ({period_start.date()} to {period_end.date()}): {e}"
+            )
             continue
-    
-    logger.info(f"Successfully retrieved {len(all_dataframes)} periods out of {len(periods)}")
+
+    logger.info(
+        f"Successfully retrieved {len(all_dataframes)} periods out of {len(periods)}"
+    )
     return all_dataframes
 
 
-def merge_period_dataframes(dataframes: List[pd.DataFrame]) -> pd.DataFrame:
+def merge_period_dataframes(dataframes: list[pd.DataFrame]) -> pd.DataFrame:
     """
     Merge DataFrames from multiple periods and remove duplicates
-    
+
     Args:
         dataframes: List of DataFrames to merge
-        
+
     Returns:
         Combined DataFrame with duplicates removed
     """
     if not dataframes:
         logger.warning("No dataframes to merge")
         return pd.DataFrame()
-    
+
     # Combine all dataframes
     combined_df = pd.concat(dataframes, ignore_index=True)
-    logger.info(f"Combined {len(dataframes)} periods into {len(combined_df)} total records")
-    
+    logger.info(
+        f"Combined {len(dataframes)} periods into {len(combined_df)} total records"
+    )
+
     # Remove duplicates based on key fields
     # Use document_mrid and start_time/end_time as the primary key for deduplication
     # This focuses on actual outage periods rather than data reporting periods
-    key_columns = ['document_mrid', 'timeseries_mrid', 'start_time', 'end_time']
-    
+    key_columns = ["document_mrid", "timeseries_mrid", "start_time", "end_time"]
+
     # Only use columns that exist in the dataframe
     existing_key_columns = [col for col in key_columns if col in combined_df.columns]
-    
+
     # If start_time/end_time not available, fall back to period_start/period_end
-    if 'start_time' not in existing_key_columns and 'period_start' in combined_df.columns:
-        key_columns = ['document_mrid', 'timeseries_mrid', 'period_start', 'period_end']
-        existing_key_columns = [col for col in key_columns if col in combined_df.columns]
-    
+    if (
+        "start_time" not in existing_key_columns
+        and "period_start" in combined_df.columns
+    ):
+        key_columns = ["document_mrid", "timeseries_mrid", "period_start", "period_end"]
+        existing_key_columns = [
+            col for col in key_columns if col in combined_df.columns
+        ]
+
     if existing_key_columns:
         initial_count = len(combined_df)
-        combined_df = combined_df.drop_duplicates(subset=existing_key_columns, keep='first')
+        combined_df = combined_df.drop_duplicates(
+            subset=existing_key_columns, keep="first"
+        )
         removed_count = initial_count - len(combined_df)
-        
+
         if removed_count > 0:
-            logger.info(f"Removed {removed_count} duplicate records, {len(combined_df)} records remaining")
-    
+            logger.info(
+                f"Removed {removed_count} duplicate records, {len(combined_df)} records remaining"
+            )
+
     # Sort by start time and resource name
-    if 'start_time' in combined_df.columns:
-        combined_df = combined_df.sort_values(['start_time', 'resource_name'])
-    elif 'period_start' in combined_df.columns:
-        combined_df = combined_df.sort_values(['period_start', 'resource_name'])
-    
+    if "start_time" in combined_df.columns:
+        combined_df = combined_df.sort_values(["start_time", "resource_name"])
+    elif "period_start" in combined_df.columns:
+        combined_df = combined_df.sort_values(["period_start", "resource_name"])
+
     return combined_df
 
 
-def parse_unavailability_zip(zip_content: bytes, save_xml_dir: Optional[str] = None) -> pd.DataFrame:
+def parse_unavailability_zip(
+    zip_content: bytes, save_xml_dir: Optional[str] = None
+) -> pd.DataFrame:
     """
     Parse ZIP file containing XML unavailability data
-    
+
     Args:
         zip_content: ZIP file content as bytes
         save_xml_dir: Optional directory to save extracted XML files
-        
+
     Returns:
         DataFrame with parsed unavailability data
     """
     outages = []
-    
+
     try:
         with zipfile.ZipFile(io.BytesIO(zip_content)) as zf:
-            xml_files = [f for f in zf.namelist() if f.endswith('.xml')]
+            xml_files = [f for f in zf.namelist() if f.endswith(".xml")]
             logger.info(f"Processing ZIP file with {len(xml_files)} XML files")
-            
+
             # Create save directory if specified
             if save_xml_dir:
                 save_path = Path(save_xml_dir)
                 save_path.mkdir(parents=True, exist_ok=True)
                 logger.info(f"Saving XML files to: {save_path}")
-            
+
             for filename in xml_files:
                 try:
-                    xml_content = zf.read(filename).decode('utf-8')
-                    
+                    xml_content = zf.read(filename).decode("utf-8")
+
                     # Save XML file if directory specified
                     if save_xml_dir:
                         xml_file_path = save_path / filename
-                        with open(xml_file_path, 'w', encoding='utf-8') as f:
+                        with open(xml_file_path, "w", encoding="utf-8") as f:
                             f.write(xml_content)
                         logger.debug(f"Saved {filename} to {xml_file_path}")
-                    
+
                     file_outages = parse_xml_content(xml_content, filename)
                     outages.extend(file_outages)
-                    
+
                 except Exception as e:
                     logger.error(f"Error processing {filename}: {e}")
                     continue
-                    
+
     except zipfile.BadZipFile as e:
         logger.error(f"Invalid ZIP file: {e}")
         return pd.DataFrame()
-    
+
     if not outages:
         logger.warning("No outage data found in ZIP file")
         return pd.DataFrame()
-    
+
     df = pd.DataFrame(outages)
     logger.info(f"Parsed {len(df)} outage records from ZIP file")
     return df
 
 
-def parse_xml_content(xml_content: str, filename: str = "") -> List[Dict]:
+def parse_xml_content(xml_content: str, filename: str = "") -> list[dict]:
     """
     Parse individual XML content for unavailability data
-    
+
     Args:
         xml_content: XML content as string
         filename: Optional filename for logging
-        
+
     Returns:
         List of outage dictionaries
     """
     outages = []
-    
+
     try:
         root = ET.fromstring(xml_content)
-        namespaces = {'ns': 'urn:iec62325.351:tc57wg16:451-6:outagedocument:3:0'}
-        
+        namespaces = {"ns": "urn:iec62325.351:tc57wg16:451-6:outagedocument:3:0"}
+
         # Extract document-level information
-        doc_mrid = _get_text(root, './/ns:mRID', namespaces)
-        doc_revision = _get_text(root, './/ns:revisionNumber', namespaces)
-        doc_status = _get_text(root, './/ns:docStatus/ns:value', namespaces)
-        
+        doc_mrid = _get_text(root, ".//ns:mRID", namespaces)
+        doc_revision = _get_text(root, ".//ns:revisionNumber", namespaces)
+        doc_status = _get_text(root, ".//ns:docStatus/ns:value", namespaces)
+
         # Find all TimeSeries elements
-        timeseries_elements = root.findall('.//ns:TimeSeries', namespaces)
-        
+        timeseries_elements = root.findall(".//ns:TimeSeries", namespaces)
+
         for ts in timeseries_elements:
             outage_data = {}
-            
+
             # Document information
-            outage_data['document_mrid'] = doc_mrid
-            outage_data['revision_number'] = doc_revision
-            outage_data['doc_status'] = doc_status
-            outage_data['source_file'] = filename
-            
+            outage_data["document_mrid"] = doc_mrid
+            outage_data["revision_number"] = doc_revision
+            outage_data["doc_status"] = doc_status
+            outage_data["source_file"] = filename
+
             # TimeSeries information
-            outage_data['timeseries_mrid'] = _get_text(ts, './/ns:mRID', namespaces)
-            outage_data['business_type'] = _get_text(ts, './/ns:businessType', namespaces)
-            outage_data['bidding_zone'] = _get_text(ts, './/ns:biddingZone_Domain.mRID', namespaces)
-            
+            outage_data["timeseries_mrid"] = _get_text(ts, ".//ns:mRID", namespaces)
+            outage_data["business_type"] = _get_text(
+                ts, ".//ns:businessType", namespaces
+            )
+            outage_data["bidding_zone"] = _get_text(
+                ts, ".//ns:biddingZone_Domain.mRID", namespaces
+            )
+
             # Resource information
-            outage_data['resource_mrid'] = _get_text(ts, './/ns:production_RegisteredResource.mRID', namespaces)
-            outage_data['resource_name'] = _get_text(ts, './/ns:production_RegisteredResource.name', namespaces)
-            outage_data['resource_location'] = _get_text(ts, './/ns:production_RegisteredResource.location.name', namespaces)
-            outage_data['resource_type'] = _get_text(ts, './/ns:production_RegisteredResource.pSRType.psrType', namespaces)
-            
+            outage_data["resource_mrid"] = _get_text(
+                ts, ".//ns:production_RegisteredResource.mRID", namespaces
+            )
+            outage_data["resource_name"] = _get_text(
+                ts, ".//ns:production_RegisteredResource.name", namespaces
+            )
+            outage_data["resource_location"] = _get_text(
+                ts, ".//ns:production_RegisteredResource.location.name", namespaces
+            )
+            outage_data["resource_type"] = _get_text(
+                ts, ".//ns:production_RegisteredResource.pSRType.psrType", namespaces
+            )
+
             # Power system resource details
-            outage_data['psr_mrid'] = _get_text(ts, './/ns:production_RegisteredResource.pSRType.powerSystemResources.mRID', namespaces)
-            outage_data['psr_name'] = _get_text(ts, './/ns:production_RegisteredResource.pSRType.powerSystemResources.name', namespaces)
-            nominal_power = _get_text(ts, './/ns:production_RegisteredResource.pSRType.powerSystemResources.nominalP', namespaces)
-            outage_data['nominal_power_mw'] = float(nominal_power) if nominal_power else None
-            
+            outage_data["psr_mrid"] = _get_text(
+                ts,
+                ".//ns:production_RegisteredResource.pSRType.powerSystemResources.mRID",
+                namespaces,
+            )
+            outage_data["psr_name"] = _get_text(
+                ts,
+                ".//ns:production_RegisteredResource.pSRType.powerSystemResources.name",
+                namespaces,
+            )
+            nominal_power = _get_text(
+                ts,
+                ".//ns:production_RegisteredResource.pSRType.powerSystemResources.nominalP",
+                namespaces,
+            )
+            outage_data["nominal_power_mw"] = (
+                float(nominal_power) if nominal_power else None
+            )
+
             # Time periods from TimeSeries level
-            start_date = _get_text(ts, './/ns:start_DateAndOrTime.date', namespaces)
-            start_time = _get_text(ts, './/ns:start_DateAndOrTime.time', namespaces)
-            end_date = _get_text(ts, './/ns:end_DateAndOrTime.date', namespaces)
-            end_time = _get_text(ts, './/ns:end_DateAndOrTime.time', namespaces)
-            
+            start_date = _get_text(ts, ".//ns:start_DateAndOrTime.date", namespaces)
+            start_time = _get_text(ts, ".//ns:start_DateAndOrTime.time", namespaces)
+            end_date = _get_text(ts, ".//ns:end_DateAndOrTime.date", namespaces)
+            end_time = _get_text(ts, ".//ns:end_DateAndOrTime.time", namespaces)
+
             if start_date and start_time:
-                outage_data['start_time'] = pd.to_datetime(f"{start_date} {start_time}")
+                outage_data["start_time"] = pd.to_datetime(f"{start_date} {start_time}")
             if end_date and end_time:
-                outage_data['end_time'] = pd.to_datetime(f"{end_date} {end_time}")
-            
+                outage_data["end_time"] = pd.to_datetime(f"{end_date} {end_time}")
+
             # Process Available_Period elements
-            available_periods = ts.findall('.//ns:Available_Period', namespaces)
-            
+            available_periods = ts.findall(".//ns:Available_Period", namespaces)
+
             if available_periods:
                 for period in available_periods:
                     period_data = outage_data.copy()
-                    
+
                     # Period-specific time interval
-                    interval_start = _get_text(period, './/ns:timeInterval/ns:start', namespaces)
-                    interval_end = _get_text(period, './/ns:timeInterval/ns:end', namespaces)
-                    
+                    interval_start = _get_text(
+                        period, ".//ns:timeInterval/ns:start", namespaces
+                    )
+                    interval_end = _get_text(
+                        period, ".//ns:timeInterval/ns:end", namespaces
+                    )
+
                     if interval_start:
-                        period_data['period_start'] = pd.to_datetime(interval_start)
+                        period_data["period_start"] = pd.to_datetime(interval_start)
                     if interval_end:
-                        period_data['period_end'] = pd.to_datetime(interval_end)
-                    
+                        period_data["period_end"] = pd.to_datetime(interval_end)
+
                     # Resolution
-                    period_data['resolution'] = _get_text(period, './/ns:resolution', namespaces)
-                    
+                    period_data["resolution"] = _get_text(
+                        period, ".//ns:resolution", namespaces
+                    )
+
                     # Extract data points
-                    points = period.findall('.//ns:Point', namespaces)
+                    points = period.findall(".//ns:Point", namespaces)
                     if points:
                         quantities = []
                         for point in points:
-                            qty = _get_text(point, './/ns:quantity', namespaces)
+                            qty = _get_text(point, ".//ns:quantity", namespaces)
                             if qty:
                                 quantities.append(float(qty))
-                        
+
                         if quantities:
-                            period_data['min_available_mw'] = min(quantities)
-                            period_data['max_available_mw'] = max(quantities)
-                            period_data['avg_available_mw'] = sum(quantities) / len(quantities)
-                            period_data['num_data_points'] = len(quantities)
-                            
+                            period_data["min_available_mw"] = min(quantities)
+                            period_data["max_available_mw"] = max(quantities)
+                            period_data["avg_available_mw"] = sum(quantities) / len(
+                                quantities
+                            )
+                            period_data["num_data_points"] = len(quantities)
+
                             # Calculate unavailable capacity
-                            if outage_data['nominal_power_mw']:
-                                period_data['min_unavailable_mw'] = max(0, outage_data['nominal_power_mw'] - max(quantities))
-                                period_data['max_unavailable_mw'] = max(0, outage_data['nominal_power_mw'] - min(quantities))
-                    
+                            if outage_data["nominal_power_mw"]:
+                                period_data["min_unavailable_mw"] = max(
+                                    0, outage_data["nominal_power_mw"] - max(quantities)
+                                )
+                                period_data["max_unavailable_mw"] = max(
+                                    0, outage_data["nominal_power_mw"] - min(quantities)
+                                )
+
                     outages.append(period_data)
             else:
                 # No Available_Period elements, just add the TimeSeries data
                 outages.append(outage_data)
-                
+
     except ET.ParseError as e:
         logger.error(f"Failed to parse XML {filename}: {e}")
     except Exception as e:
         logger.error(f"Error processing XML {filename}: {e}")
-    
+
     return outages
 
 
-def _get_text(element, xpath: str, namespaces: Dict[str, str]) -> Optional[str]:
+def _get_text(element, xpath: str, namespaces: dict[str, str]) -> Optional[str]:
     """
     Helper function to safely extract text from XML element
-    
+
     Args:
         element: XML element
         xpath: XPath expression
         namespaces: XML namespaces
-        
+
     Returns:
         Text content or None
     """
@@ -468,13 +529,11 @@ def _get_text(element, xpath: str, namespaces: Dict[str, str]) -> Optional[str]:
 
 
 def process_unavailability_data(
-    df: pd.DataFrame,
-    output_file: str,
-    bidding_zone: str
+    df: pd.DataFrame, output_file: str, bidding_zone: str
 ) -> None:
     """
     Process and save unavailability data
-    
+
     Args:
         df: DataFrame with raw unavailability data
         output_file: Path to save processed data
@@ -483,158 +542,148 @@ def process_unavailability_data(
     if df.empty:
         logger.warning("No data to process")
         # Create empty CSV with headers
-        empty_df = pd.DataFrame(columns=[
-            'document_mrid', 'resource_mrid', 'resource_name', 'resource_location',
-            'resource_type', 'business_type', 'doc_status',
-            'start_time', 'end_time', 'period_start', 'period_end',
-            'nominal_power_mw', 'min_available_mw', 'max_available_mw', 'avg_available_mw',
-            'min_unavailable_mw', 'max_unavailable_mw',
-            'bidding_zone'
-        ])
+        empty_df = pd.DataFrame(
+            columns=[
+                "document_mrid",
+                "resource_mrid",
+                "resource_name",
+                "resource_location",
+                "resource_type",
+                "business_type",
+                "doc_status",
+                "start_time",
+                "end_time",
+                "period_start",
+                "period_end",
+                "nominal_power_mw",
+                "min_available_mw",
+                "max_available_mw",
+                "avg_available_mw",
+                "min_unavailable_mw",
+                "max_unavailable_mw",
+                "bidding_zone",
+            ]
+        )
         empty_df.to_csv(output_file, index=False)
         return
-    
+
     # Add bidding zone information
-    df['bidding_zone'] = bidding_zone
-    
+    df["bidding_zone"] = bidding_zone
+
     # Clean and process data
-    df['business_type_desc'] = df['business_type'].map({
-        'A53': 'Planned maintenance',
-        'A54': 'Forced unavailability'
-    })
-    
-    df['doc_status_desc'] = df['doc_status'].map({
-        'A05': 'Active',
-        'A09': 'Cancelled',
-        'A13': 'Withdrawn'
-    })
-    
+    df["business_type_desc"] = df["business_type"].map(
+        {"A53": "Planned maintenance", "A54": "Forced unavailability"}
+    )
+
+    df["doc_status_desc"] = df["doc_status"].map(
+        {"A05": "Active", "A09": "Cancelled", "A13": "Withdrawn"}
+    )
+
     # Sort by start time
-    df = df.sort_values(['start_time', 'resource_name'])
-    
+    df = df.sort_values(["start_time", "resource_name"])
+
     # Save processed data
     df.to_csv(output_file, index=False)
     logger.info(f"Saved {len(df)} records to {output_file}")
-    
+
     # Print summary statistics
     logger.info("Data summary:")
-    if 'start_time' in df.columns and not df['start_time'].isnull().all():
+    if "start_time" in df.columns and not df["start_time"].isnull().all():
         logger.info(f"  Date range: {df['start_time'].min()} to {df['end_time'].max()}")
     logger.info(f"  Total outage records: {len(df)}")
     logger.info(f"  Unique generation units: {df['resource_name'].nunique()}")
-    
-    if 'nominal_power_mw' in df.columns and not df['nominal_power_mw'].isnull().all():
-        logger.info(f"  Total installed capacity: {df['nominal_power_mw'].sum():.1f} MW")
-    
+
+    if "nominal_power_mw" in df.columns and not df["nominal_power_mw"].isnull().all():
+        logger.info(
+            f"  Total installed capacity: {df['nominal_power_mw'].sum():.1f} MW"
+        )
+
     # Business type breakdown
-    if 'business_type_desc' in df.columns:
-        business_breakdown = df.groupby('business_type_desc').agg({
-            'resource_name': 'nunique',
-            'document_mrid': 'count'
-        }).round(1)
-        business_breakdown.columns = ['Unique_Units', 'Total_Records']
+    if "business_type_desc" in df.columns:
+        business_breakdown = (
+            df.groupby("business_type_desc")
+            .agg({"resource_name": "nunique", "document_mrid": "count"})
+            .round(1)
+        )
+        business_breakdown.columns = ["Unique_Units", "Total_Records"]
         logger.info(f"  Breakdown by type:\\n{business_breakdown}")
 
 
 def create_xml_index(xml_dir: str) -> pd.DataFrame:
     """
     Create an index of stored XML files with metadata
-    
+
     Args:
         xml_dir: Directory containing XML files
-        
+
     Returns:
         DataFrame with XML file metadata
     """
     xml_path = Path(xml_dir)
     if not xml_path.exists():
         return pd.DataFrame()
-    
-    xml_files = list(xml_path.glob('*.xml'))
+
+    xml_files = list(xml_path.glob("*.xml"))
     if not xml_files:
         return pd.DataFrame()
-    
+
     index_data = []
-    
+
     for xml_file in xml_files:
         try:
             # Extract metadata from filename
             filename = xml_file.name
-            
+
             # Parse basic file info
             file_info = {
-                'filename': filename,
-                'filepath': str(xml_file),
-                'size_bytes': xml_file.stat().st_size,
-                'modified_time': datetime.fromtimestamp(xml_file.stat().st_mtime)
+                "filename": filename,
+                "filepath": str(xml_file),
+                "size_bytes": xml_file.stat().st_size,
+                "modified_time": datetime.fromtimestamp(xml_file.stat().st_mtime),
             }
-            
+
             # Try to extract period from filename
-            if 'PLANNED_UNAVAIL_OF_GENERATION_UNITS_' in filename:
-                parts = filename.split('PLANNED_UNAVAIL_OF_GENERATION_UNITS_')[1].replace('.xml', '')
-                if '-' in parts:
-                    start_str, end_str = parts.split('-')
+            if "PLANNED_UNAVAIL_OF_GENERATION_UNITS_" in filename:
+                parts = filename.split("PLANNED_UNAVAIL_OF_GENERATION_UNITS_")[
+                    1
+                ].replace(".xml", "")
+                if "-" in parts:
+                    start_str, end_str = parts.split("-")
                     try:
-                        file_info['period_start'] = pd.to_datetime(start_str, format='%Y%m%d%H%M')
-                        file_info['period_end'] = pd.to_datetime(end_str, format='%Y%m%d%H%M')
-                    except:
+                        file_info["period_start"] = pd.to_datetime(
+                            start_str, format="%Y%m%d%H%M"
+                        )
+                        file_info["period_end"] = pd.to_datetime(
+                            end_str, format="%Y%m%d%H%M"
+                        )
+                    except (ValueError, TypeError):
                         pass
-            
+
             index_data.append(file_info)
-            
+
         except Exception as e:
             logger.warning(f"Error indexing {xml_file}: {e}")
             continue
-    
+
     if index_data:
         df = pd.DataFrame(index_data)
         # Save index file
-        index_file = xml_path / 'xml_index.csv'
+        index_file = xml_path / "xml_index.csv"
         df.to_csv(index_file, index=False)
         logger.info(f"Created XML index with {len(df)} files: {index_file}")
         return df
-    
+
     return pd.DataFrame()
-
-
-def cleanup_xml_storage(base_dir: str = "data/gb-model/outage_data", max_age_days: int = 30):
-    """
-    Clean up old XML files to manage storage space
-    
-    Args:
-        base_dir: Base directory for XML storage
-        max_age_days: Maximum age of files to keep
-    """
-    base_path = Path(base_dir)
-    if not base_path.exists():
-        return
-    
-    cutoff_time = datetime.now() - timedelta(days=max_age_days)
-    deleted_count = 0
-    deleted_size = 0
-    
-    for xml_file in base_path.rglob('*.xml'):
-        try:
-            if datetime.fromtimestamp(xml_file.stat().st_mtime) < cutoff_time:
-                file_size = xml_file.stat().st_size
-                xml_file.unlink()
-                deleted_count += 1
-                deleted_size += file_size
-        except Exception as e:
-            logger.warning(f"Error deleting {xml_file}: {e}")
-    
-    if deleted_count > 0:
-        logger.info(f"Cleaned up {deleted_count} old XML files ({deleted_size/1024/1024:.1f} MB)")
 
 
 def test_api_connection(api_client, zone_code: str) -> bool:
     """
     Test API connection with a small date range
-    
+
     Args:
         api_client: ENTSOEUnavailabilityAPI instance
         zone_code: EIC code for bidding zone
-        
+
     Returns:
         True if API connection works
     """
@@ -642,24 +691,26 @@ def test_api_connection(api_client, zone_code: str) -> bool:
         # Test with a recent date range
         test_start = datetime.now() - timedelta(days=30)
         test_end = datetime.now() - timedelta(days=29)
-        
-        logger.info(f"Testing API connection with date range: {test_start.date()} to {test_end.date()}")
-        
+
+        logger.info(
+            f"Testing API connection with date range: {test_start.date()} to {test_end.date()}"
+        )
+
         response_content = api_client.get_unavailability_data(
             bidding_zone=zone_code,
             period_start=test_start,
             period_end=test_end,
             business_type="A53",  # Planned maintenance
         )
-        
+
         logger.info(f"Test API response length: {len(response_content)} bytes")
-        
+
         # Check if it's a ZIP file
-        is_zip = response_content.startswith(b'PK')
+        is_zip = response_content.startswith(b"PK")
         logger.info(f"Response is ZIP format: {is_zip}")
-        
+
         return True
-        
+
     except Exception as e:
         logger.error(f"API connection test failed: {e}")
         return False
@@ -668,70 +719,77 @@ def test_api_connection(api_client, zone_code: str) -> bool:
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from scripts._helpers import mock_snakemake
+
         snakemake = mock_snakemake("retrieve_unavailability_data")
-    
+
     configure_logging(snakemake)
     set_scenario_config(snakemake)
-    
+
     # Load environment variables from .env file
     load_dotenv()
-    
+
     # Get API key from environment variable
     api_key = os.getenv("ENTSO_E_API_KEY")
-    
+
     if not api_key:
         raise ValueError(
             "ENTSO-E API key not found. Please set ENTSO_E_API_KEY in your .env file or environment variables.\\n"
             "You can get an API key from: https://transparency.entsoe.eu/usrm/user/createPublicApiUser.do"
         )
-    
+
     # Get date parameters from config or use defaults
-    start_date = pd.to_datetime(snakemake.config.get("unavailability_start_date", "2023-01-01"))
-    end_date = pd.to_datetime(snakemake.config.get("unavailability_end_date", "2023-12-31"))
-    
+    start_date = pd.to_datetime(
+        snakemake.config.get("unavailability_start_date", "2023-01-01")
+    )
+    end_date = pd.to_datetime(
+        snakemake.config.get("unavailability_end_date", "2023-12-31")
+    )
+
     bidding_zones = snakemake.config.get("unavailability_bidding_zones", ["GB"])
-    business_types = snakemake.config.get("unavailability_business_types", ["planned", "forced"])
+    business_types = snakemake.config.get(
+        "unavailability_business_types", ["planned", "forced"]
+    )
     max_request_days = snakemake.config.get("max_request_days", 7)
-    
-    logger.info(f"Configuration loaded:")
-    logger.info(f"  Date range: {start_date.date()} to {end_date.date()}")
-    logger.info(f"  Bidding zones: {bidding_zones}")
-    logger.info(f"  Business types: {business_types}")
-    logger.info(f"  Max request days: {max_request_days}")
-    
+
     # Initialize API client
     api_client = ENTSOEUnavailabilityAPI(api_key)
-    
+
     # Test API connection first
     logger.info("Testing API connection...")
     if not test_api_connection(api_client, UK_BIDDING_ZONES["GB"]):
-        raise ConnectionError("API connection test failed. Check your API key and network connection.")
-    
+        raise ConnectionError(
+            "API connection test failed. Check your API key and network connection."
+        )
+
     # Process each bidding zone
     for zone in bidding_zones:
         if zone not in UK_BIDDING_ZONES:
             logger.warning(f"Unknown bidding zone: {zone}")
             continue
-            
+
         zone_code = UK_BIDDING_ZONES[zone]
         logger.info(f"Retrieving unavailability data for {zone} ({zone_code})")
-        
+
         # Process each business type
         for business_type in business_types:
             if business_type not in BUSINESS_TYPES:
                 logger.warning(f"Unknown business type: {business_type}")
                 continue
-                
+
             business_code = BUSINESS_TYPES[business_type]
             logger.info(f"Processing {business_type} outages ({business_code})")
-            
+
             try:
                 # Split the date range into weekly periods
-                periods = generate_weekly_periods(start_date, end_date, max_days=max_request_days)
-                
+                periods = generate_weekly_periods(
+                    start_date, end_date, max_days=max_request_days
+                )
+
                 # Create XML storage directory
-                xml_save_dir = f"data/gb-model/outage_data/{zone.lower()}_{business_type}"
-                
+                xml_save_dir = (
+                    f"data/gb-model/outage_data/{zone.lower()}_{business_type}"
+                )
+
                 # Retrieve data for all periods
                 all_dataframes = retrieve_data_by_periods(
                     api_client=api_client,
@@ -739,41 +797,46 @@ if __name__ == "__main__":
                     periods=periods,
                     business_type=business_code,
                     doc_status=DOC_STATUS["active"],
-                    xml_save_dir=xml_save_dir
+                    xml_save_dir=xml_save_dir,
                 )
-                
+
                 # Merge all periods into a single DataFrame
                 df = merge_period_dataframes(all_dataframes)
                 logger.info(f"Final merged DataFrame has {len(df)} rows")
-                
+
                 # Generate output filename
-                output_file = snakemake.output[f"{zone.lower()}_{business_type}_unavailability"]
-                
+                output_file = snakemake.output[
+                    f"{zone.lower()}_{business_type}_unavailability"
+                ]
+
                 # Process and save data
                 process_unavailability_data(df, output_file, zone)
-                
+
                 # Log XML storage information across all periods
                 xml_base_dir = Path(xml_save_dir)
                 if xml_base_dir.exists():
                     # Count XML files across all period subdirectories
-                    total_xml_count = len(list(xml_base_dir.rglob('*.xml')))
-                    total_size = sum(f.stat().st_size for f in xml_base_dir.rglob('*.xml'))
-                    
-                    period_dirs = [d for d in xml_base_dir.iterdir() if d.is_dir() and d.name.startswith('period_')]
-                    
-                    logger.info(f"Stored {total_xml_count} XML files ({total_size/1024/1024:.1f} MB) across {len(period_dirs)} periods in {xml_base_dir}")
-                    
+                    total_xml_count = len(list(xml_base_dir.rglob("*.xml")))
+                    total_size = sum(
+                        f.stat().st_size for f in xml_base_dir.rglob("*.xml")
+                    )
+
+                    period_dirs = [
+                        d
+                        for d in xml_base_dir.iterdir()
+                        if d.is_dir() and d.name.startswith("period_")
+                    ]
+
+                    logger.info(
+                        f"Stored {total_xml_count} XML files ({total_size / 1024 / 1024:.1f} MB) across {len(period_dirs)} periods in {xml_base_dir}"
+                    )
+
                     # Create XML index for the overall collection
                     create_xml_index(xml_save_dir)
-                
+
             except Exception as e:
                 logger.error(f"Failed to process {zone} {business_type} data: {e}")
                 logger.exception("Full traceback:")
                 continue
-    
-    # Clean up old XML files if configured
-    cleanup_days = snakemake.config.get("xml_cleanup_days", 30)
-    if cleanup_days > 0:
-        cleanup_xml_storage(max_age_days=cleanup_days)
-    
+
     logger.info("Unavailability data retrieval completed")

--- a/scripts/gb-model/retrieve_unavailability_data.py
+++ b/scripts/gb-model/retrieve_unavailability_data.py
@@ -731,9 +731,7 @@ if __name__ == "__main__":
             logger.info(f"Final merged DataFrame has {len(df)} rows")
 
             # Generate output filename
-            output_file = snakemake.output[
-                f"{zone.lower()}_{business_type}_unavailability"
-            ]
+            output_file = snakemake.output[f"{business_type}_unavailability"]
 
             # Process and save data
             process_unavailability_data(df, output_file, zone, snakemake.config)


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
Good day. This PR aims to add a rule to retrieve the unavailability information of GB generation units from ENTSO-E API. Retrieval from API has limitations, as it allows to retrieve a data for a 7 day period at once. Therefore, the script loops through weeks of 2023 (just taken as default for now) and finally produces `planned_unavailability.csv` and `forced_unavailability.csv`. The output contains EIC code of the powerplant and start and end time of outage that could be used in the following rules. The format of the output as shown below:
<img width="850" height="230" alt="image" src="https://github.com/user-attachments/assets/eb2ef9f6-70b7-45b7-b348-1af94033b6fb" />

### Instructions
1. To retrieve the data, it is necessary to register to [ENSTSO-E transparency platform](https://transparency.entsoe.eu/) and obtain API key. Individual API key needs to be placed into `.env` file with variable name `ENTSO_E_API_KEY` (e.g. `ENTSO_E_API_KEY=aaa-bbb-ccc`). 
2. It is necessary to install `python-dotenv`.  It can be installed with `conda install python-dotenv`. Or it is possible just update the current environment by `conda env update -n pypsa-eur -f envs/environment.yaml`, as `python-dotenv` was added to the environment file.
These instructions should appear in the `readme` in the future, as it will start to have a nice format.

### Notes
* Currently, 2 seconds wait time is set between two requests. Because with lower time, I have faced the issue with API key probably being blocked for too many consecutive requests. The error message was 503, which is server side error, but might be due to blockage of my API key for too many requests.
* Alternatively, unavailability times can be extracted from excel sheets downloaded manually from the ENTSO-E site (e.g. is [here](https://transparency.entsoe.eu/outage-domain/r2/unavailabilityOfProductionAndGenerationUnits/show?name=&defaultValue=false&viewType=TABLE&areaType=CTA&atch=false&dateTime.dateTime=01.01.2023+00:00|UTC|DAY&dateTime.endDateTime=31.12.2023+00:00|UTC|DAY&area.values=CTY|10Y1001A1001A92E!CTA|10YGB----------A&assetType.values=PU&assetType.values=GU&outageType.values=A54&outageType.values=A53&outageStatus.values=A05&masterDataFilterName=&masterDataFilterCode=&dv-datatable_length=10#)). However, files are not managed well, so you can extract 100 entries one at a time. Also those files only include powerplant outage time and name. EIC codes mapping needs to be extracted from another table. Thus, using API seems more automated way.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.